### PR TITLE
对反序列化添加校验

### DIFF
--- a/src/main/java/com/alibaba/com/caucho/hessian/io/Hessian2Input.java
+++ b/src/main/java/com/alibaba/com/caucho/hessian/io/Hessian2Input.java
@@ -2822,6 +2822,12 @@ public class Hessian2Input
     private void readObjectDefinition(Class cl)
             throws IOException {
         String type = readString();
+
+        if (cl != null && !cl.getName().equals(type)) {
+            log.log(Level.SEVERE, "Hessian2Input#readObjectDefinition Dubbo Provider反序列化安全检查失败，clazz:" + cl.getName() + ", type:" + type);
+            throw new IllegalArgumentException("Hessian反序列化失败，类型不一致");
+        }
+
         int len = readInt();
 
         String[] fieldNames = new String[len];
@@ -3203,6 +3209,7 @@ public class Hessian2Input
             return false;
 
         int code = _offset < _length ? (_buffer[_offset++] & 0xff) : read();
+        break;
 
         switch (code) {
             case BC_STRING_CHUNK:


### PR DESCRIPTION
参见：https://github.com/apache/dubbo/pull/5733#issuecomment-626606397

org.apache.dubbo.rpc.protocol.dubbo.DecodeableRpcInvocation#decode方法中
                args = new Object[pts.length];
                for (int i = 0; i < args.length; i++) {
                    try {
                        args[i] = in.readObject(pts[i]);
                    } catch (Exception e) {
                        if (log.isWarnEnabled()) {
                            log.warn("Decode argument failed: " + e.getMessage(), e);
                        }
                    }
                }

 in.readObject 在内部的反序列化是没有使用传入的类型（即pts[i]）