### PR TITLE
Fix broken unit tests due to strict Serializable interface restrictions

### DIFF
--- a/src/test/java/com/alibaba/com/caucho/hessian/io/CollectionSerializerTest.java
+++ b/src/test/java/com/alibaba/com/caucho/hessian/io/CollectionSerializerTest.java
@@ -38,7 +38,7 @@ public class CollectionSerializerTest extends SerializeTestBase {
         set.add(1111);
         set.add(2222);
 
-        Set deserialize = baseHessianSerialize(set);
+        Set deserialize = baseHessianSerialize(set, true);
         Assert.assertTrue(deserialize.equals(set));
     }
 

--- a/src/test/java/com/alibaba/com/caucho/hessian/io/Hessian1StringShortTest.java
+++ b/src/test/java/com/alibaba/com/caucho/hessian/io/Hessian1StringShortTest.java
@@ -44,7 +44,7 @@ public class Hessian1StringShortTest extends SerializeTestBase {
         stringShortMap.put("last", (short)60);
         stringShort.stringShortMap = stringShortMap;
 
-        Hessian2StringShortType deserialize = baseHessianSerialize(stringShort);
+        Hessian2StringShortType deserialize = baseHessianSerialize(stringShort, true);
         assertTrue(deserialize.stringShortMap != null);
         assertTrue(deserialize.stringShortMap.size() == 2);
         assertTrue(deserialize.stringShortMap.get("last") instanceof Short);
@@ -61,7 +61,7 @@ public class Hessian1StringShortTest extends SerializeTestBase {
         stringByteMap.put("last", (byte)60);
         stringShort.stringByteMap = stringByteMap;
 
-        Hessian2StringShortType deserialize = baseHessianSerialize(stringShort);
+        Hessian2StringShortType deserialize = baseHessianSerialize(stringShort, true);
         assertTrue(deserialize.stringByteMap != null);
         assertTrue(deserialize.stringByteMap.size() == 2);
         assertTrue(deserialize.stringByteMap.get("last") instanceof Byte);
@@ -140,6 +140,7 @@ public class Hessian1StringShortTest extends SerializeTestBase {
 
         ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
         HessianInput input = new HessianInput(bin);
+        input._serializerFactory.setAllowNonSerializable(true);
 
         Hessian2StringShortType deserialize = (Hessian2StringShortType) input.readObject();
         assertTrue(deserialize.stringPersonTypeMap != null);

--- a/src/test/java/com/alibaba/com/caucho/hessian/io/Hessian2ReuseTest.java
+++ b/src/test/java/com/alibaba/com/caucho/hessian/io/Hessian2ReuseTest.java
@@ -33,13 +33,19 @@ public class Hessian2ReuseTest extends SerializeTestBase {
 
     private static final Hessian2Output h2o = new Hessian2Output(null);
 
-    @SuppressWarnings("unchecked")
     private static <T> T serializeAndDeserialize(T obj, Class<T> clazz) throws IOException {
+        return serializeAndDeserialize(obj, clazz, false);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T serializeAndDeserialize(T obj, Class<T> clazz, boolean isAllowNonSerializable) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        h2o.findSerializerFactory().setAllowNonSerializable(isAllowNonSerializable);
         h2o.init(outputStream);
         h2o.writeObject(obj);
         h2o.flush();
 
+        h2i.findSerializerFactory().setAllowNonSerializable(isAllowNonSerializable);
         h2i.init(new ByteArrayInputStream(outputStream.toByteArray()));
         return (T) h2i.readObject(clazz);
     }
@@ -143,10 +149,10 @@ public class Hessian2ReuseTest extends SerializeTestBase {
             PersonType abc = new PersonType("ABC", 12, 128D, (short) 1, (byte) 2, shorts);
             obj.stringPersonTypeMap.put("P_" + i, abc);
 
-            Hessian2StringShortType newObj = serializeAndDeserialize(obj, Hessian2StringShortType.class);
+            Hessian2StringShortType newObj = serializeAndDeserialize(obj, Hessian2StringShortType.class, true);
             Assert.assertEquals(obj, newObj);
 
-            Hessian2StringShortType newObj2 = baseHessian2Serialize(obj);
+            Hessian2StringShortType newObj2 = baseHessian2Serialize(obj, true);
             Assert.assertEquals(newObj, newObj2);
         }
     }

--- a/src/test/java/com/alibaba/com/caucho/hessian/io/Hessian2StringShortTest.java
+++ b/src/test/java/com/alibaba/com/caucho/hessian/io/Hessian2StringShortTest.java
@@ -42,7 +42,7 @@ public class Hessian2StringShortTest extends SerializeTestBase {
         stringShortMap.put("last", (short) 60);
         stringShort.stringShortMap = stringShortMap;
 
-        Hessian2StringShortType deserialize = baseHessian2Serialize(stringShort);
+        Hessian2StringShortType deserialize = baseHessian2Serialize(stringShort, true);
         assertTrue(deserialize.stringShortMap != null);
         assertTrue(deserialize.stringShortMap.size() == 2);
         assertTrue(deserialize.stringShortMap.get("last") instanceof Short);
@@ -59,7 +59,7 @@ public class Hessian2StringShortTest extends SerializeTestBase {
         stringByteMap.put("last", (byte) 60);
         stringShort.stringByteMap = stringByteMap;
 
-        Hessian2StringShortType deserialize = baseHessian2Serialize(stringShort);
+        Hessian2StringShortType deserialize = baseHessian2Serialize(stringShort, true);
         assertTrue(deserialize.stringByteMap != null);
         assertTrue(deserialize.stringByteMap.size() == 2);
         assertTrue(deserialize.stringByteMap.get("last") instanceof Byte);
@@ -105,6 +105,7 @@ public class Hessian2StringShortTest extends SerializeTestBase {
 
         ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
         Hessian2Input input = new Hessian2Input(bin);
+        input.findSerializerFactory().setAllowNonSerializable(true);
 
         List<Class<?>> keyValueType = new ArrayList<Class<?>>();
         keyValueType.add(String.class);
@@ -139,6 +140,7 @@ public class Hessian2StringShortTest extends SerializeTestBase {
 
         ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
         Hessian2Input input = new Hessian2Input(bin);
+        input.findSerializerFactory().setAllowNonSerializable(true);
 
         Hessian2StringShortType deserialize = (Hessian2StringShortType) input.readObject();
         assertTrue(deserialize.stringPersonTypeMap != null);
@@ -215,7 +217,7 @@ public class Hessian2StringShortTest extends SerializeTestBase {
         shortSet.add((short) 60);
         stringShort.shortSet = shortSet;
 
-        Hessian2StringShortType deserialize = baseHessian2Serialize(stringShort);
+        Hessian2StringShortType deserialize = baseHessian2Serialize(stringShort, true);
         assertTrue(deserialize.shortSet != null);
         assertTrue(deserialize.shortSet.size() == 2);
         assertTrue(deserialize.shortSet.contains((short) 0));
@@ -242,7 +244,7 @@ public class Hessian2StringShortTest extends SerializeTestBase {
             PersonType abc = new PersonType("ABC", 12, 128D, (short) 1, (byte) 2, shorts);
             obj.stringPersonTypeMap.put("P_" + i, abc);
 
-            Hessian2StringShortType newObj = baseHessian2Serialize(obj);
+            Hessian2StringShortType newObj = baseHessian2Serialize(obj, true);
             Assert.assertEquals(obj, newObj);
             System.out.println("ShortTypeTest.testHessian2StringShortType(): i=" + i + " passed!");
         }

--- a/src/test/java/com/alibaba/com/caucho/hessian/io/Hessian2UUIDTest.java
+++ b/src/test/java/com/alibaba/com/caucho/hessian/io/Hessian2UUIDTest.java
@@ -60,6 +60,7 @@ public class Hessian2UUIDTest extends SerializeTestBase {
 
 		ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
 		Hessian2Input input = new Hessian2Input(bin);
+		input.findSerializerFactory().setAllowNonSerializable(true);
 
 		Map<UUID, Object> deserialize = (Map<UUID, Object>) input.readObject();
 		assertTrue(deserialize != null);

--- a/src/test/java/com/alibaba/com/caucho/hessian/io/base/SerializeTestBase.java
+++ b/src/test/java/com/alibaba/com/caucho/hessian/io/base/SerializeTestBase.java
@@ -34,19 +34,34 @@ public class SerializeTestBase {
      * hessian serialize util
      *
      * @param data
-     * @param <T>
      * @return
+     * @param <T>
      * @throws IOException
      */
     protected <T> T baseHessianSerialize(T data) throws IOException {
+        return baseHessianSerialize(data, false);
+    }
+
+    /**
+     * hessian serialize util
+     *
+     * @param data
+     * @param isAllowNonSerializable
+     * @return
+     * @param <T>
+     * @throws IOException
+     */
+    protected <T> T baseHessianSerialize(T data, boolean isAllowNonSerializable) throws IOException {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         HessianOutput out = new HessianOutput(bout);
+        out.getSerializerFactory().setAllowNonSerializable(isAllowNonSerializable);
 
         out.writeObject(data);
         out.flush();
 
         ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
         HessianInput input = new HessianInput(bin);
+        input.getSerializerFactory().setAllowNonSerializable(isAllowNonSerializable);
         return (T) input.readObject();
     }
 
@@ -54,19 +69,34 @@ public class SerializeTestBase {
      * hessian2 serialize util
      *
      * @param data
-     * @param <T>
      * @return
+     * @param <T>
      * @throws IOException
      */
     protected <T> T baseHessian2Serialize(T data) throws IOException {
+        return baseHessian2Serialize(data, false);
+    }
+
+    /**
+     * hessian2 serialize util
+     *
+     * @param data
+     * @param isAllowNonSerializable
+     * @return
+     * @param <T>
+     * @throws IOException
+     */
+    protected <T> T baseHessian2Serialize(T data, boolean isAllowNonSerializable) throws IOException {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         Hessian2Output out = new Hessian2Output(bout);
+        out.findSerializerFactory().setAllowNonSerializable(isAllowNonSerializable);
 
         out.writeObject(data);
         out.flush();
 
         ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
         Hessian2Input input = new Hessian2Input(bin);
+        input.findSerializerFactory().setAllowNonSerializable(isAllowNonSerializable);
         return (T) input.readObject();
     }
 }


### PR DESCRIPTION
Because `java.util.Map` and `java.util.Set` do not implement the Serializable interface, but https://github.com/apache/dubbo-hessian-lite/commit/99d689cf47c00b664db89bc8dff44dcd595b6ea6 imposes strict restrictions.