### PR TITLE
Optimize serialization performance of Java 8 date/time types.

### DIFF
--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/DurationHandle.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/DurationHandle.java
@@ -20,7 +20,7 @@ package com.alibaba.com.caucho.hessian.io.java8;
 import com.alibaba.com.caucho.hessian.io.HessianHandle;
 
 import java.io.Serializable;
-import java.lang.reflect.Method;
+import java.time.Duration;
 
 
 @SuppressWarnings("unchecked")
@@ -35,11 +35,9 @@ public class DurationHandle implements HessianHandle, Serializable {
 
     public DurationHandle(Object o) {
         try {
-            Class c = Class.forName("java.time.Duration");
-            Method m = c.getDeclaredMethod("getSeconds");
-            this.seconds = (Long) m.invoke(o);
-            m = c.getDeclaredMethod("getNano");
-            this.nanos = (Integer) m.invoke(o);
+            Duration duration = (Duration) o;
+            this.seconds = duration.getSeconds();
+            this.nanos = duration.getNano();
         } catch (Throwable t) {
             // ignore
         }
@@ -47,9 +45,7 @@ public class DurationHandle implements HessianHandle, Serializable {
 
     private Object readResolve() {
         try {
-            Class c = Class.forName("java.time.Duration");
-            Method m = c.getDeclaredMethod("ofSeconds", long.class, long.class);
-            return m.invoke(null, seconds, nanos);
+            return Duration.ofSeconds(seconds, nanos);
         } catch (Throwable t) {
             // ignore
         }

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/InstantHandle.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/InstantHandle.java
@@ -20,7 +20,7 @@ package com.alibaba.com.caucho.hessian.io.java8;
 import com.alibaba.com.caucho.hessian.io.HessianHandle;
 
 import java.io.Serializable;
-import java.lang.reflect.Method;
+import java.time.Instant;
 
 @SuppressWarnings("unchecked")
 public class InstantHandle implements HessianHandle, Serializable {
@@ -34,11 +34,9 @@ public class InstantHandle implements HessianHandle, Serializable {
 
     public InstantHandle(Object o) {
         try {
-            Class c = Class.forName("java.time.Instant");
-            Method m = c.getDeclaredMethod("getEpochSecond");
-            this.seconds = (Long) m.invoke(o);
-            m = c.getDeclaredMethod("getNano");
-            this.nanos = (Integer) m.invoke(o);
+            Instant instant = (Instant) o;
+            this.seconds = instant.getEpochSecond();
+            this.nanos = instant.getNano();
         } catch (Throwable t) {
             // ignore
         }
@@ -47,9 +45,7 @@ public class InstantHandle implements HessianHandle, Serializable {
 
     private Object readResolve() {
         try {
-            Class c = Class.forName("java.time.Instant");
-            Method m = c.getDeclaredMethod("ofEpochSecond", long.class, long.class);
-            return m.invoke(null, seconds, nanos);
+            return Instant.ofEpochSecond(seconds, nanos);
         } catch (Throwable t) {
             // ignore
         }

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/LocalDateDeserializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/LocalDateDeserializer.java
@@ -17,35 +17,26 @@
 
 package com.alibaba.com.caucho.hessian.io.java8;
 
-import com.alibaba.com.caucho.hessian.io.HessianHandle;
 
-import java.io.Serializable;
-import java.time.ZoneOffset;
+import com.alibaba.com.caucho.hessian.io.AbstractDeserializer;
+import com.alibaba.com.caucho.hessian.io.AbstractHessianInput;
 
-@SuppressWarnings("unchecked")
-public class ZoneOffsetHandle implements HessianHandle, Serializable {
-    private static final long serialVersionUID = 8841589723587858789L;
+import java.io.IOException;
+import java.time.LocalDate;
 
-    private int seconds;
+/**
+ * @author wuwen
+ */
+public class LocalDateDeserializer<T> extends AbstractDeserializer {
 
-    public ZoneOffsetHandle() {
+    @Override
+    public Object readObject(AbstractHessianInput in,
+                             Object[] fields)
+            throws IOException {
+        int encoded = in.readInt();
+        LocalDate localDate = LocalDate.of(encoded >>> 9, (encoded >>> 5) & 0b1111, encoded & 0b11111);
+        in.addRef(localDate);
+        return localDate;
     }
-
-    public ZoneOffsetHandle(Object o) {
-        try {
-            ZoneOffset zoneOffset = (ZoneOffset) o;
-            this.seconds = zoneOffset.getTotalSeconds();
-        } catch (Throwable t) {
-            // ignore
-        }
-    }
-
-    private Object readResolve() {
-        try {
-            return ZoneOffset.ofTotalSeconds(seconds);
-        } catch (Throwable t) {
-            // ignore
-        }
-        return null;
-    }
+    
 }

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/LocalDateHandle.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/LocalDateHandle.java
@@ -20,28 +20,25 @@ package com.alibaba.com.caucho.hessian.io.java8;
 import com.alibaba.com.caucho.hessian.io.HessianHandle;
 
 import java.io.Serializable;
-import java.lang.reflect.Method;
+import java.time.LocalDate;
 
 @SuppressWarnings("unchecked")
 public class LocalDateHandle implements HessianHandle, Serializable {
     private static final long serialVersionUID = 166018689500019951L;
 
-    private int year;
-    private int month;
-    private int day;
+    int year;
+    int month;
+    int day;
 
     public LocalDateHandle() {
     }
 
     public LocalDateHandle(Object o) {
         try {
-            Class c = Class.forName("java.time.LocalDate");
-            Method m = c.getDeclaredMethod("getYear");
-            this.year = (Integer) m.invoke(o);
-            m = c.getDeclaredMethod("getMonthValue");
-            this.month = (Integer) m.invoke(o);
-            m = c.getDeclaredMethod("getDayOfMonth");
-            this.day = (Integer) m.invoke(o);
+            LocalDate date = (LocalDate) o;
+            this.year = date.getYear();
+            this.month = date.getMonthValue();
+            this.day = date.getDayOfMonth();
         } catch (Throwable t) {
             // ignore
         }
@@ -49,9 +46,7 @@ public class LocalDateHandle implements HessianHandle, Serializable {
 
     public Object readResolve() {
         try {
-            Class c = Class.forName("java.time.LocalDate");
-            Method m = c.getDeclaredMethod("of", int.class, int.class, int.class);
-            return m.invoke(null, year, month, day);
+            return LocalDate.of(year, month, day);
         } catch (Throwable t) {
             // ignore
         }

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/LocalDateTimeDeserializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/LocalDateTimeDeserializer.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.com.caucho.hessian.io.java8;
+
+
+import com.alibaba.com.caucho.hessian.io.AbstractDeserializer;
+import com.alibaba.com.caucho.hessian.io.AbstractHessianInput;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+/**
+ * @author wuwen
+ */
+public class LocalDateTimeDeserializer<T> extends AbstractDeserializer {
+
+    @Override
+    public Object readObject(AbstractHessianInput in,
+                             Object[] fieldNames)
+            throws IOException {
+
+        LocalDate localDate = null;
+        LocalTime localTime = null;
+        for (Object fieldName : fieldNames) {
+            if ("date".equals(fieldName)) {
+                localDate = (LocalDate) in.readObject();
+            } else if ("time".equals(fieldName)) {
+                localTime = (LocalTime) in.readObject();
+            } else {
+                in.readObject();
+            }
+        }
+
+        if (localDate == null || localTime == null) {
+            throw new IOException("Missing required fields for LocalDateTime deserialization: "
+                    + "date=" + localDate + ", time=" + localTime);
+        }
+        
+        LocalDateTime localDateTime = LocalDateTime.of(localDate, localTime);
+
+        in.addRef(localDateTime);
+        return localDateTime;
+    }
+    
+}

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/LocalDateTimeHandle.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/LocalDateTimeHandle.java
@@ -20,25 +20,25 @@ package com.alibaba.com.caucho.hessian.io.java8;
 import com.alibaba.com.caucho.hessian.io.HessianHandle;
 
 import java.io.Serializable;
-import java.lang.reflect.Method;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @SuppressWarnings("unchecked")
 public class LocalDateTimeHandle implements HessianHandle, Serializable {
     private static final long serialVersionUID = 7563825215275989361L;
 
-    private Object date;
-    private Object time;
+    private LocalDate date;
+    private LocalTime time;
 
     public LocalDateTimeHandle() {
     }
 
     public LocalDateTimeHandle(Object o) {
         try {
-            Class c = Class.forName("java.time.LocalDateTime");
-            Method m = c.getDeclaredMethod("toLocalDate");
-            date = m.invoke(o);
-            m = c.getDeclaredMethod("toLocalTime");
-            time = m.invoke(o);
+            LocalDateTime localDateTime = (LocalDateTime) o;
+            date = localDateTime.toLocalDate();
+            time = localDateTime.toLocalTime();
         } catch (Throwable t) {
             // ignore
         }
@@ -46,10 +46,7 @@ public class LocalDateTimeHandle implements HessianHandle, Serializable {
 
     private Object readResolve() {
         try {
-            Class c = Class.forName("java.time.LocalDateTime");
-            Method m = c.getDeclaredMethod("of", Class.forName("java.time.LocalDate"),
-                    Class.forName("java.time.LocalTime"));
-            return m.invoke(null, date, time);
+            return LocalDateTime.of(date, time);
         } catch (Throwable t) {
             // ignore
         }

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/LocalDateTimeSerializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/LocalDateTimeSerializer.java
@@ -22,9 +22,12 @@ import com.alibaba.com.caucho.hessian.io.AbstractHessianOutput;
 import com.alibaba.com.caucho.hessian.io.AbstractSerializer;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 
 public class LocalDateTimeSerializer<T> extends AbstractSerializer {
 
+    private final boolean useBitEncoding = Boolean.getBoolean("com.caucho.hessian.io.java.time.serializer.useBitEncoding");
+    
     @Override
     public void writeObject(Object obj, AbstractHessianOutput out) throws IOException {
         if (obj == null) {
@@ -32,6 +35,35 @@ public class LocalDateTimeSerializer<T> extends AbstractSerializer {
             return;
         }
 
-        out.writeObject(new LocalDateTimeHandle(obj));
+        if (!useBitEncoding) {
+            out.writeObject(new LocalDateTimeHandle(obj));
+        } else {
+            if (out.addRef(obj)) {
+                return;
+            }
+
+            Class<?> cl = obj.getClass();
+
+            int ref = out.writeObjectBegin(cl.getName());
+
+            LocalDateTime localDateTime = (LocalDateTime) obj;
+
+            if (ref < -1) {
+                out.writeString("date");
+                out.writeObject(localDateTime.toLocalDate());
+                out.writeString("time");
+                out.writeObject(localDateTime.toLocalTime());
+                out.writeMapEnd();
+            } else {
+                if (ref == -1) {
+                    out.writeInt(2);
+                    out.writeString("date");
+                    out.writeString("time");
+                    out.writeObjectBegin(cl.getName());
+                }
+                out.writeObject(localDateTime.toLocalDate());
+                out.writeObject(localDateTime.toLocalTime());
+            }   
+        }
     }
 }

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/LocalTimeDeserializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/LocalTimeDeserializer.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.com.caucho.hessian.io.java8;
+
+
+import com.alibaba.com.caucho.hessian.io.AbstractDeserializer;
+import com.alibaba.com.caucho.hessian.io.AbstractHessianInput;
+
+import java.io.IOException;
+import java.time.LocalTime;
+
+/**
+ * @author wuwen
+ */
+public class LocalTimeDeserializer<T> extends AbstractDeserializer {
+
+    @Override
+    public Object readObject(AbstractHessianInput in,
+                             Object[] fields)
+            throws IOException {
+        LocalTime localTime = decodeTime(in.readLong());
+        in.addRef(localTime);
+        return localTime;
+    }
+
+    private static LocalTime decodeTime(long encoded) {
+        int hour = (int) (encoded >>> 47);
+        int minute = (int) ((encoded >>> 41) & 0b111111);
+        int second = (int) ((encoded >>> 35) & 0b111111);
+        // 0x3FFFFFFF is used to mask the last 30 bits for nanoseconds
+        int nano = (int) (encoded & 0x3FFFFFFF);
+        return LocalTime.of(hour, minute, second, nano);
+    }
+    
+}

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/LocalTimeHandle.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/LocalTimeHandle.java
@@ -21,7 +21,7 @@ package com.alibaba.com.caucho.hessian.io.java8;
 import com.alibaba.com.caucho.hessian.io.HessianHandle;
 
 import java.io.Serializable;
-import java.lang.reflect.Method;
+import java.time.LocalTime;
 
 @SuppressWarnings("unchecked")
 public class LocalTimeHandle implements HessianHandle, Serializable {
@@ -37,15 +37,11 @@ public class LocalTimeHandle implements HessianHandle, Serializable {
 
     public LocalTimeHandle(Object o) {
         try {
-            Class c = Class.forName("java.time.LocalTime");
-            Method m = c.getDeclaredMethod("getHour");
-            this.hour = (Integer) m.invoke(o);
-            m = c.getDeclaredMethod("getMinute");
-            this.minute = (Integer) m.invoke(o);
-            m = c.getDeclaredMethod("getSecond");
-            this.second = (Integer) m.invoke(o);
-            m = c.getDeclaredMethod("getNano");
-            this.nano = (Integer) m.invoke(o);
+            LocalTime localTime = (LocalTime) o;
+            this.hour = localTime.getHour();
+            this.minute = localTime.getMinute();
+            this.second = localTime.getSecond();
+            this.nano = localTime.getNano();
         } catch (Throwable t) {
             // ignore
         }
@@ -53,9 +49,7 @@ public class LocalTimeHandle implements HessianHandle, Serializable {
 
     private Object readResolve() {
         try {
-            Class c = Class.forName("java.time.LocalTime");
-            Method m = c.getDeclaredMethod("of", int.class, int.class, int.class, int.class);
-            return m.invoke(null, hour, minute, second, nano);
+            return LocalTime.of(hour, minute, second, nano);
         } catch (Throwable t) {
             // ignore
         }

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/MonthDayHandle.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/MonthDayHandle.java
@@ -20,7 +20,7 @@ package com.alibaba.com.caucho.hessian.io.java8;
 import com.alibaba.com.caucho.hessian.io.HessianHandle;
 
 import java.io.Serializable;
-import java.lang.reflect.Method;
+import java.time.MonthDay;
 
 @SuppressWarnings("unchecked")
 public class MonthDayHandle implements HessianHandle, Serializable {
@@ -34,11 +34,9 @@ public class MonthDayHandle implements HessianHandle, Serializable {
 
     public MonthDayHandle(Object o) {
         try {
-            Class c = Class.forName("java.time.MonthDay");
-            Method m = c.getDeclaredMethod("getMonthValue");
-            this.month = (Integer) m.invoke(o);
-            m = c.getDeclaredMethod("getDayOfMonth");
-            this.day = (Integer) m.invoke(o);
+            MonthDay monthDay = (MonthDay) o;
+            this.month = monthDay.getMonthValue();
+            this.day = monthDay.getDayOfMonth();
         } catch (Throwable t) {
             // ignore
         }
@@ -46,9 +44,7 @@ public class MonthDayHandle implements HessianHandle, Serializable {
 
     private Object readResolve() {
         try {
-            Class c = Class.forName("java.time.MonthDay");
-            Method m = c.getDeclaredMethod("of", int.class, int.class);
-            return m.invoke(null, month, day);
+            return MonthDay.of(month, day);
         } catch (Throwable t) {
             // ignore
         }

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/OffsetDateTimeHandle.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/OffsetDateTimeHandle.java
@@ -20,25 +20,25 @@ package com.alibaba.com.caucho.hessian.io.java8;
 import com.alibaba.com.caucho.hessian.io.HessianHandle;
 
 import java.io.Serializable;
-import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 @SuppressWarnings("unchecked")
 public class OffsetDateTimeHandle implements HessianHandle, Serializable {
     private static final long serialVersionUID = -7823900532640515312L;
 
-    private Object dateTime;
-    private Object offset;
+    private LocalDateTime dateTime;
+    private ZoneOffset offset;
 
     public OffsetDateTimeHandle() {
     }
 
     public OffsetDateTimeHandle(Object o) {
         try {
-            Class c = Class.forName("java.time.OffsetDateTime");
-            Method m = c.getDeclaredMethod("toLocalDateTime");
-            this.dateTime = m.invoke(o);
-            m = c.getDeclaredMethod("getOffset");
-            this.offset = m.invoke(o);
+            OffsetDateTime offsetDateTime = (OffsetDateTime) o;
+            this.dateTime = offsetDateTime.toLocalDateTime();
+            this.offset = offsetDateTime.getOffset();
         } catch (Throwable t) {
             // ignore
         }
@@ -47,10 +47,7 @@ public class OffsetDateTimeHandle implements HessianHandle, Serializable {
     private Object readResolve() {
 
         try {
-            Class c = Class.forName("java.time.OffsetDateTime");
-            Method m = c.getDeclaredMethod("of", Class.forName("java.time.LocalDateTime"),
-                    Class.forName("java.time.ZoneOffset"));
-            return m.invoke(null, dateTime, offset);
+            return OffsetDateTime.of(dateTime, offset);
         } catch (Throwable t) {
             // ignore
         }

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/OffsetTimeHandle.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/OffsetTimeHandle.java
@@ -20,25 +20,25 @@ package com.alibaba.com.caucho.hessian.io.java8;
 import com.alibaba.com.caucho.hessian.io.HessianHandle;
 
 import java.io.Serializable;
-import java.lang.reflect.Method;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
 
 @SuppressWarnings("unchecked")
 public class OffsetTimeHandle implements HessianHandle, Serializable {
     private static final long serialVersionUID = -3269846941421652860L;
 
-    private Object localTime;
-    private Object zoneOffset;
+    private LocalTime localTime;
+    private ZoneOffset zoneOffset;
 
     public OffsetTimeHandle() {
     }
 
     public OffsetTimeHandle(Object o) {
         try {
-            Class c = Class.forName("java.time.OffsetTime");
-            Method m = c.getDeclaredMethod("getOffset");
-            this.zoneOffset = m.invoke(o);
-            m = c.getDeclaredMethod("toLocalTime");
-            this.localTime = m.invoke(o);
+            OffsetTime offsetTime = (OffsetTime) o;
+            this.zoneOffset = offsetTime.getOffset();
+            this.localTime = offsetTime.toLocalTime();
         } catch (Throwable t) {
             // ignore
         }
@@ -46,10 +46,7 @@ public class OffsetTimeHandle implements HessianHandle, Serializable {
 
     private Object readResolve() {
         try {
-            Class c = Class.forName("java.time.OffsetTime");
-            Method m = c.getDeclaredMethod("of", Class.forName("java.time.LocalTime"),
-                    Class.forName("java.time.ZoneOffset"));
-            return m.invoke(null, localTime, zoneOffset);
+            return OffsetTime.of(localTime, zoneOffset);
         } catch (Throwable t) {
             // ignore
         }

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/PeriodHandle.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/PeriodHandle.java
@@ -20,7 +20,7 @@ package com.alibaba.com.caucho.hessian.io.java8;
 import com.alibaba.com.caucho.hessian.io.HessianHandle;
 
 import java.io.Serializable;
-import java.lang.reflect.Method;
+import java.time.Period;
 
 
 @SuppressWarnings("unchecked")
@@ -36,13 +36,10 @@ public class PeriodHandle implements HessianHandle, Serializable {
 
     public PeriodHandle(Object o) {
         try {
-            Class c = Class.forName("java.time.Period");
-            Method m = c.getDeclaredMethod("getYears");
-            this.years = (Integer) m.invoke(o);
-            m = c.getDeclaredMethod("getMonths");
-            this.months = (Integer) m.invoke(o);
-            m = c.getDeclaredMethod("getDays");
-            this.days = (Integer) m.invoke(o);
+            Period period = (Period) o;
+            this.years = period.getYears();
+            this.months = period.getMonths();
+            this.days = period.getDays();
         } catch (Throwable t) {
             // ignore
         }
@@ -50,9 +47,7 @@ public class PeriodHandle implements HessianHandle, Serializable {
 
     private Object readResolve() {
         try {
-            Class c = Class.forName("java.time.Period");
-            Method m = c.getDeclaredMethod("of", int.class, int.class, int.class);
-            return m.invoke(null, years, months, days);
+            return Period.of(years, months, days);
         } catch (Throwable t) {
             // ignore
         }

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/YearHandle.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/YearHandle.java
@@ -20,7 +20,7 @@ package com.alibaba.com.caucho.hessian.io.java8;
 import com.alibaba.com.caucho.hessian.io.HessianHandle;
 
 import java.io.Serializable;
-import java.lang.reflect.Method;
+import java.time.Year;
 
 @SuppressWarnings("unchecked")
 public class YearHandle implements HessianHandle, Serializable {
@@ -33,9 +33,8 @@ public class YearHandle implements HessianHandle, Serializable {
 
     public YearHandle(Object o) {
         try {
-            Class c = Class.forName("java.time.Year");
-            Method m = c.getDeclaredMethod("getValue");
-            this.year = (Integer) m.invoke(o);
+            Year yearObj = (Year) o;
+            this.year = yearObj.getValue();
         } catch (Throwable t) {
             // ignore
         }
@@ -44,9 +43,7 @@ public class YearHandle implements HessianHandle, Serializable {
 
     private Object readResolve() {
         try {
-            Class c = Class.forName("java.time.Year");
-            Method m = c.getDeclaredMethod("of", int.class);
-            return m.invoke(null, year);
+            return Year.of(year);
         } catch (Throwable t) {
             // ignore
         }

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/YearMonthHandle.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/YearMonthHandle.java
@@ -20,7 +20,7 @@ package com.alibaba.com.caucho.hessian.io.java8;
 import com.alibaba.com.caucho.hessian.io.HessianHandle;
 
 import java.io.Serializable;
-import java.lang.reflect.Method;
+import java.time.YearMonth;
 
 @SuppressWarnings("unchecked")
 public class YearMonthHandle implements HessianHandle, Serializable {
@@ -34,11 +34,9 @@ public class YearMonthHandle implements HessianHandle, Serializable {
 
     public YearMonthHandle(Object o) {
         try {
-            Class c = Class.forName("java.time.YearMonth");
-            Method m = c.getDeclaredMethod("getYear");
-            this.year = (Integer) m.invoke(o);
-            m = c.getDeclaredMethod("getMonthValue");
-            this.month = (Integer) m.invoke(o);
+            YearMonth yearMonth = (YearMonth) o;
+            this.year = yearMonth.getYear();
+            this.month = yearMonth.getMonthValue();
         } catch (Throwable t) {
             // ignore
         }
@@ -46,9 +44,7 @@ public class YearMonthHandle implements HessianHandle, Serializable {
 
     private Object readResolve() {
         try {
-            Class c = Class.forName("java.time.YearMonth");
-            Method m = c.getDeclaredMethod("of", int.class, int.class);
-            return m.invoke(null, year, month);
+            return YearMonth.of(year, month);
         } catch (Throwable t) {
             // ignore
         }

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/ZoneIdHandle.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/java8/ZoneIdHandle.java
@@ -20,7 +20,7 @@ package com.alibaba.com.caucho.hessian.io.java8;
 import com.alibaba.com.caucho.hessian.io.HessianHandle;
 
 import java.io.Serializable;
-import java.lang.reflect.Method;
+import java.time.ZoneId;
 
 @SuppressWarnings("unchecked")
 public class ZoneIdHandle implements HessianHandle, Serializable {
@@ -34,9 +34,8 @@ public class ZoneIdHandle implements HessianHandle, Serializable {
 
     public ZoneIdHandle(Object o) {
         try {
-            Class c = Class.forName("java.time.ZoneId");
-            Method m = c.getDeclaredMethod("getId");
-            this.zoneId = (String) m.invoke(o);
+            ZoneId zoneIdObj = (ZoneId) o;
+            this.zoneId = zoneIdObj.getId();
         } catch (Throwable t) {
             // ignore
         }
@@ -44,9 +43,7 @@ public class ZoneIdHandle implements HessianHandle, Serializable {
 
     private Object readResolve() {
         try {
-            Class c = Class.forName("java.time.ZoneId");
-            Method m = c.getDeclaredMethod("of", String.class);
-            return m.invoke(null, this.zoneId);
+            return ZoneId.of(this.zoneId);
         } catch (Throwable t) {
             // ignore
         }

--- a/hessian-lite/src/main/resources/META-INF/dubbo/hessian/deserializers
+++ b/hessian-lite/src/main/resources/META-INF/dubbo/hessian/deserializers
@@ -12,3 +12,6 @@ java.net.URI=com.alibaba.com.caucho.hessian.io.socket.URIDeserializer
 java.time.temporal.WeekFields=com.alibaba.com.caucho.hessian.io.java8.WeekFieldsDeserializer
 java.util.UUID=com.alibaba.com.caucho.hessian.io.UUIDDeserializer
 java.util.Currency=com.alibaba.com.caucho.hessian.io.CurrencyDeserializer
+java.time.LocalDate=com.alibaba.com.caucho.hessian.io.java8.LocalDateDeserializer
+java.time.LocalDateTime=com.alibaba.com.caucho.hessian.io.java8.LocalDateTimeDeserializer
+java.time.LocalTime=com.alibaba.com.caucho.hessian.io.java8.LocalTimeDeserializer

--- a/java-8-test/pom.xml
+++ b/java-8-test/pom.xml
@@ -39,6 +39,18 @@
             <version>4.0.4-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.37</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.37</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/HessianDateBenchmark.java
+++ b/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/HessianDateBenchmark.java
@@ -1,0 +1,92 @@
+package com.alibaba.com.caucho.hessian.io.java8;
+
+import com.alibaba.com.caucho.hessian.io.base.SerializeTestBase;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author wuwen
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup
+@Fork(1)
+public abstract class HessianDateBenchmark extends SerializeTestBase {
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(HessianDateBenchmark.class.getSimpleName())
+                .build();
+
+        new Runner(opt).run();
+    }
+    
+    @State(Scope.Thread)
+    public static class JavaUtilDateBenchmark extends HessianDateBenchmark {
+        protected Date javaUtilDate;
+        @Setup
+        public void setup() {
+            javaUtilDate = new Date();
+        }
+        @Benchmark
+        public Object serializeDeserializeJavaUtilDate() throws Exception {
+            return baseHessian2Serialize(javaUtilDate);
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class LocalDateTimeBenchmark extends HessianDateBenchmark {
+        @Param({"true", "false"})
+        public String useBitEncoding;
+        
+        protected LocalDateTime javaTimeLocalDateTime;
+        
+        @Setup(Level.Iteration)
+        public void setUp() {
+            javaTimeLocalDateTime = LocalDateTime.now();
+            System.setProperty("com.caucho.hessian.io.java.time.serializer.useBitEncoding", useBitEncoding);
+        }
+
+        @Benchmark
+        public Object serializeDeserializeLocalDateTime() throws Exception {
+            return baseHessian2Serialize(javaTimeLocalDateTime);
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class LocalDateBenchmark extends HessianDateBenchmark {
+        protected LocalDate javaTimeLocalDate;
+
+        @Param({"true", "false"})
+        public String useBitEncoding;
+        
+        @Setup(Level.Iteration)
+        public void setUp() {
+            javaTimeLocalDate = LocalDate.now();
+            System.setProperty("com.caucho.hessian.io.java.time.serializer.useBitEncoding", useBitEncoding);
+        }
+
+        @Benchmark
+        public Object serializeDeserializeLocalDate() throws Exception {
+            return baseHessian2Serialize(javaTimeLocalDate);
+        }
+    }
+}

--- a/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/Java8TimeSerializerTest.java
+++ b/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/Java8TimeSerializerTest.java
@@ -152,7 +152,7 @@ public class Java8TimeSerializerTest extends SerializeTestBase {
         testJava8Time(ChronoPeriod.between(ThaiBuddhistDate.now(), ThaiBuddhistDate.now()));
     }
 
-    private void testJava8Time(Object expected) throws IOException {
+    protected void testJava8Time(Object expected) throws IOException {
         Assertions.assertEquals(expected, baseHessian2Serialize(expected));
         if (expected instanceof Chronology || expected instanceof ChronoPeriod || expected instanceof JapaneseDate
                 || expected instanceof HijrahDate || expected instanceof MinguoDate || expected instanceof ThaiBuddhistDate) {

--- a/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/Java8TimeSerializerUseBitEncodingTest.java
+++ b/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/Java8TimeSerializerUseBitEncodingTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.com.caucho.hessian.io.java8;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.io.IOException;
+import java.time.chrono.ChronoPeriod;
+import java.time.chrono.Chronology;
+import java.time.chrono.HijrahDate;
+import java.time.chrono.JapaneseDate;
+import java.time.chrono.MinguoDate;
+import java.time.chrono.ThaiBuddhistDate;
+
+/**
+ * Test Java8TimeSerializer class use bit wise encoding
+ */
+public class Java8TimeSerializerUseBitEncodingTest extends Java8TimeSerializerTest {
+
+    @BeforeEach
+    public void setUp() {
+        System.setProperty("com.caucho.hessian.io.java.time.serializer.useBitEncoding", "true");
+    }
+
+    protected void testJava8Time(Object expected) throws IOException {
+        Assertions.assertEquals(expected, baseHessian2Serialize(expected));
+        if (expected instanceof Chronology || expected instanceof ChronoPeriod || expected instanceof JapaneseDate
+                || expected instanceof HijrahDate || expected instanceof MinguoDate || expected instanceof ThaiBuddhistDate) {
+            return;
+        }
+        Assertions.assertEquals(expected, hessian3ToHessian3(expected));
+        Assertions.assertEquals(expected, hessian3ToHessian4(expected));
+    }
+}


### PR DESCRIPTION
Resolve #83 

Add bitwise encoding support for Java 8 date/time types.

Benchmark test results:

```
Benchmark                                                  (useBitEncoding)   Mode  Cnt     Score    Error   Units
JavaUtilDateBenchmark.serializeDeserializeJavaUtilDate                 N/A  thrpt    5  1172.447 ± 24.973  ops/ms
LocalDateBenchmark.serializeDeserializeLocalDate                      true  thrpt    5   909.220 ± 73.025  ops/ms  (use BitEncoding)
LocalDateBenchmark.serializeDeserializeLocalDate                     false  thrpt    5   663.492 ± 17.049  ops/ms  (directly codes)
LocalDateBenchmark.serializeDeserializeLocalDate                            thrpt   25   291.155 ± 10.315  ops/ms  (old reflection codes)

LocalDateTimeBenchmark.serializeDeserializeLocalDateTime              true  thrpt    5   580.540 ±  8.875  ops/ms  (use BitEncoding)
LocalDateTimeBenchmark.serializeDeserializeLocalDateTime             false  thrpt    5   319.611 ± 13.268  ops/ms  (directly codes)
LocalDateTimeBenchmark.serializeDeserializeLocalDateTime                    thrpt    5   140.318 ± 1.013   ops/ms  (old reflection codes)
```