### PR TITLE
perf: Optimize unnecessary getInterfaces and getSuperclass calls

### DIFF
--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/ClassFactory.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/ClassFactory.java
@@ -139,10 +139,9 @@ public class ClassFactory {
             for (Class<?> anInterface : aClass.getInterfaces()) {
                 String interfaceName = anInterface.getName();
                 if (!isAllow(interfaceName)) {
-                log.log(Level.SEVERE, className + "'s interfaces: " + interfaceName
-                    + " in blacklist or not in whitelist, deserialization with type 'HashMap' instead.");
-                return HashMap.class;
-              }
+                    log.log(Level.SEVERE, className + "'s interfaces: " + interfaceName + " in blacklist or not in whitelist, deserialization with type 'HashMap' instead.");
+                    return HashMap.class;
+                }
             }
 
             Class<?> superClass = aClass.getSuperclass();


### PR DESCRIPTION
Optimize unnecessary getInterfaces and getSuperclass calls, which have a high overhead compared to getClass.
For getInterfaces the for loop will check its size without checking its length.
For superClass, there is no need to put all superClass or even Object.class into an unused list