### PR TITLE
fix: Calendar Serializer causes ref count errors, refer to com.alibaba.com.caucho.hessian.io.WriteReplaceSerializer for repair

### DIFF
--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/CalendarHandle.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/CalendarHandle.java
@@ -49,7 +49,6 @@
 package com.alibaba.com.caucho.hessian.io;
 
 import java.util.Calendar;
-import java.util.Date;
 import java.util.GregorianCalendar;
 
 /**
@@ -57,7 +56,7 @@ import java.util.GregorianCalendar;
  */
 public class CalendarHandle implements java.io.Serializable, HessianHandle {
     private Class type;
-    private Date date;
+    private long time;
 
     public CalendarHandle() {
     }
@@ -66,7 +65,7 @@ public class CalendarHandle implements java.io.Serializable, HessianHandle {
         if (!GregorianCalendar.class.equals(type))
             this.type = type;
 
-        this.date = new Date(time);
+        this.time = time;
     }
 
     private Object readResolve() {
@@ -78,7 +77,7 @@ public class CalendarHandle implements java.io.Serializable, HessianHandle {
             else
                 cal = new GregorianCalendar();
 
-            cal.setTimeInMillis(this.date.getTime());
+            cal.setTimeInMillis(time);
 
             return cal;
         } catch (RuntimeException e) {

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/CalendarSerializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/CalendarSerializer.java
@@ -48,6 +48,7 @@
 
 package com.alibaba.com.caucho.hessian.io;
 
+import java.io.IOException;
 import java.util.Calendar;
 
 /**
@@ -58,11 +59,25 @@ public class CalendarSerializer extends AbstractSerializer {
 
     /**
      * java.util.Calendar serializes to com.alibaba.com.caucho.hessian.io.CalendarHandle
+     * @see com.alibaba.com.caucho.hessian.io.WriteReplaceSerializer#writeObject(Object, AbstractHessianOutput)
      */
     @Override
-    public Object writeReplace(Object obj) {
-        Calendar cal = (Calendar) obj;
+    public void writeObject(Object obj, AbstractHessianOutput out)
+        throws IOException {
+        int ref = out.getRef(obj);
 
-        return new CalendarHandle(cal.getClass(), cal.getTimeInMillis());
+        if (ref >= 0) {
+            out.writeRef(ref);
+
+            return;
+        }
+
+        Calendar cal = (Calendar) obj;
+        Object repl = new CalendarHandle(cal.getClass(), cal.getTimeInMillis());
+
+        out.writeObject(repl);
+
+        out.replaceRef(repl, obj);
     }
+
 }

--- a/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/CalendarTest.java
+++ b/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/CalendarTest.java
@@ -1,0 +1,25 @@
+package com.alibaba.com.caucho.hessian.io;
+
+import com.alibaba.com.caucho.hessian.io.base.SerializeTestBase;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.GregorianCalendar;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class CalendarTest extends SerializeTestBase {
+
+  @Test
+  void testCalendar() throws IOException {
+    List<Object> list = new ArrayList<>();
+
+    list.add(new GregorianCalendar());
+
+    Object obj = new Object();
+    list.add(obj);
+    list.add(obj);
+
+    baseHessian2Serialize(list);
+  }
+
+}


### PR DESCRIPTION
Calendar Serializer causes ref count errors, refer to com.alibaba.com.caucho.hessian.io.WriteReplaceSerializer for repair