### PR TITLE
Fixed addRef execution timing issue

### DIFF
--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AbstractSerializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AbstractSerializer.java
@@ -73,7 +73,8 @@ abstract public class AbstractSerializer implements Serializer {
             Object replace = writeReplace(obj);
 
             if (replace != null) {
-                // out.removeRef(obj);
+                // remove before write `replace` to ensure `ref` of `replace` is the correct location in `_refs`.
+                out.removeRef(obj);
 
                 out.writeObject(replace);
 

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AbstractSerializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AbstractSerializer.java
@@ -65,21 +65,18 @@ abstract public class AbstractSerializer implements Serializer {
     @Override
     public void writeObject(Object obj, AbstractHessianOutput out)
             throws IOException {
-        if (out.addRef(obj)) {
+        int ref = out.getRef(obj);
+        if (ref >= 0) {
+            // shared mode is true if the result of getRef is not less than zero.
+            out.writeRef(ref);
             return;
         }
 
         try {
             Object replace = writeReplace(obj);
-
             if (replace != null) {
-                // remove before write `replace` to ensure `ref` of `replace` is the correct location in `_refs`.
-                out.removeRef(obj);
-
                 out.writeObject(replace);
-
                 out.replaceRef(replace, obj);
-
                 return;
             }
         } catch (RuntimeException e) {
@@ -89,9 +86,12 @@ abstract public class AbstractSerializer implements Serializer {
             throw new HessianException(e);
         }
 
+        // add reference if writeReplace returns null and shared mode is true.
+        out.addRef(obj);
+
         Class<?> cl = getClass(obj);
 
-        int ref = out.writeObjectBegin(cl.getName());
+        ref = out.writeObjectBegin(cl.getName());
 
         if (ref < -1) {
             writeObject10(obj, out);

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/Hessian2Output.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/Hessian2Output.java
@@ -98,8 +98,8 @@ public class Hessian2Output
     private boolean _isUnshared;
 
     /**
-     * Creates a new Hessian output stream, initialized with an
-     * underlying output stream.
+     * Creates a new Hessian output stream instance without initializing it
+     * with an underlying output stream. The output stream must be set before use.
      */
     public Hessian2Output() {
     }

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/Hessian2Output.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/Hessian2Output.java
@@ -1289,7 +1289,7 @@ public class Hessian2Output
         if (value >= 0) {
             addRef(newRef, value, true);
 
-            // does not remove `oldRef` from `_refs` since it should be replaced at the same location.
+            // The oldRef is not removed from _refs because it is being replaced at the same index position to maintain reference integrity.
 
             return true;
         } else

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/Hessian2Output.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/Hessian2Output.java
@@ -1285,15 +1285,12 @@ public class Hessian2Output
         }
 
         int value = _refs.get(oldRef);
-
         if (value >= 0) {
             addRef(newRef, value, true);
-
-            // The oldRef is not removed from _refs because it is being replaced at the same index position to maintain reference integrity.
-
+            _refs.remove(oldRef);
             return true;
-        } else
-            return false;
+        }
+        return false;
     }
 
     private int addRef(Object value, int newRef, boolean isReplace) {

--- a/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/Java8TimeSerializerTest.java
+++ b/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/Java8TimeSerializerTest.java
@@ -308,7 +308,7 @@ public class Java8TimeSerializerTest extends SerializeTestBase {
     protected void testJava8Time(Object expected) throws IOException {
         Object result = baseHessian2Serialize(expected);
         Assertions.assertEquals(expected, result);
-        if (expected instanceof List && ((List) expected).get(0) instanceof Chronology) {
+        if (expected instanceof List && !((List) expected).isEmpty() && ((List) expected).get(0) instanceof Chronology) {
             return;
         }
         if (expected instanceof Chronology || expected instanceof ChronoPeriod || expected instanceof JapaneseDate

--- a/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/Java8TimeSerializerTest.java
+++ b/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/Java8TimeSerializerTest.java
@@ -243,7 +243,7 @@ public class Java8TimeSerializerTest extends SerializeTestBase {
     @Test
     public void testZoneId() throws Exception {
         List<Object> list = new ArrayList<>();
-        ZoneId zoneId = ZoneId.of( "America/New_York");
+        ZoneId zoneId = ZoneId.of("America/New_York");
         list.add(zoneId);
         list.add(zoneId);
         TestInner o = new TestInner();

--- a/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/Java8TimeSerializerTest.java
+++ b/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/Java8TimeSerializerTest.java
@@ -320,6 +320,12 @@ public class Java8TimeSerializerTest extends SerializeTestBase {
         Assertions.assertEquals(expected, hessian3ToHessian4(expected));
     }
     
+    /**
+     * Helper class used in tests to verify reference handling during serialization.
+     * Instances of this class are added multiple times to collections to ensure
+     * that object references are correctly preserved or duplicated as expected
+     * when serializing and deserializing with Hessian.
+     */
     static class TestInner implements Serializable {
         String value;
         

--- a/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/Java8TimeSerializerTest.java
+++ b/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/Java8TimeSerializerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -42,7 +43,10 @@ import java.time.chrono.HijrahDate;
 import java.time.chrono.JapaneseDate;
 import java.time.chrono.MinguoDate;
 import java.time.chrono.ThaiBuddhistDate;
+import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Test Java8TimeSerializer class
@@ -56,78 +60,212 @@ public class Java8TimeSerializerTest extends SerializeTestBase {
 
     @Test
     public void testInstant() throws Exception {
-        testJava8Time(Instant.now());
+        List<Object> list = new ArrayList<>();
+        Instant instant = Instant.now();
+        list.add(instant);
+        list.add(instant);
+        TestInner o = new TestInner();
+        list.add(o);
+        list.add(o);
+        list.add(instant);
+        list.add(o);
+        testJava8Time(list);
     }
 
     @Test
     public void testDuration() throws Exception {
-        testJava8Time(Duration.ofDays(2));
+        List<Object> list = new ArrayList<>();
+        Duration duration = Duration.ofDays(2);
+        list.add(duration);
+        list.add(duration);
+        TestInner o = new TestInner();
+        list.add(o);
+        list.add(o);
+        list.add(duration);
+        list.add(o);
+        testJava8Time(list);
     }
 
     @Test
     public void testLocalDate() throws Exception {
-        testJava8Time(LocalDate.now());
+        List<Object> list = new ArrayList<>();
+        LocalDate localDate = LocalDate.now();
+        list.add(localDate);
+        list.add(localDate);
+        TestInner o = new TestInner();
+        list.add(o);
+        list.add(o);
+        list.add(localDate);
+        list.add(o);
+        testJava8Time(list);
     }
 
     @Test
     public void testLocalDateTime() throws Exception {
-        testJava8Time(LocalDateTime.now());
+        List<Object> list = new ArrayList<>();
+        LocalDateTime localDateTime = LocalDateTime.now();
+        list.add(localDateTime);
+        list.add(localDateTime);
+        TestInner o = new TestInner();
+        list.add(o);
+        list.add(o);
+        list.add(localDateTime);
+        list.add(o);
+        testJava8Time(list);
     }
 
     @Test
     public void testLocalTime() throws Exception {
-        testJava8Time(LocalTime.now());
+        List<Object> list = new ArrayList<>();
+        LocalTime localTime = LocalTime.now();
+        list.add(localTime);
+        list.add(localTime);
+        TestInner o = new TestInner();
+        list.add(o);
+        list.add(o);
+        list.add(localTime);
+        list.add(o);
+        testJava8Time(list);
     }
 
     @Test
     public void testYear() throws Exception {
-        testJava8Time(Year.now());
+        List<Object> list = new ArrayList<>();
+        Year year = Year.now();
+        list.add(year);
+        list.add(year);
+        TestInner o = new TestInner();
+        list.add(o);
+        list.add(o);
+        list.add(year);
+        list.add(o);
+        testJava8Time(list);
     }
 
     @Test
     public void testYearMonth() throws Exception {
-        testJava8Time(YearMonth.now());
+        List<Object> list = new ArrayList<>();
+        YearMonth yearMonth = YearMonth.now();
+        list.add(yearMonth);
+        list.add(yearMonth);
+        TestInner o = new TestInner();
+        list.add(o);
+        list.add(o);
+        list.add(yearMonth);
+        list.add(o);
+        testJava8Time(list);
     }
 
     @Test
     public void testMonthDay() throws Exception {
-        testJava8Time(MonthDay.now());
+        List<Object> list = new ArrayList<>();
+        MonthDay monthDay = MonthDay.now();
+        list.add(monthDay);
+        list.add(monthDay);
+        TestInner o = new TestInner();
+        list.add(o);
+        list.add(o);
+        list.add(monthDay);
+        list.add(o);
+        testJava8Time(list);
     }
 
     @Test
     public void testPeriod() throws Exception {
-        testJava8Time(Period.ofDays(3));
+        List<Object> list = new ArrayList<>();
+        Period period = Period.ofDays(3);
+        list.add(period);
+        list.add(period);
+        TestInner o = new TestInner();
+        list.add(o);
+        list.add(o);
+        list.add(period);
+        list.add(o);
+        testJava8Time(list);
     }
 
     @Test
     public void testOffsetTime() throws Exception {
-        testJava8Time(OffsetTime.now());
+        List<Object> list = new ArrayList<>();
+        OffsetTime offsetTime = OffsetTime.now();
+        list.add(offsetTime);
+        list.add(offsetTime);
+        TestInner o = new TestInner();
+        list.add(o);
+        list.add(o);
+        list.add(offsetTime);
+        list.add(o);
+        testJava8Time(list);
     }
 
     @Test
     public void testZoneOffset() throws Exception {
-        testJava8Time(ZoneOffset.ofHours( 8));
+        List<Object> list = new ArrayList<>();
+        ZoneOffset zoneOffset = ZoneOffset.ofHours(8);
+        list.add(zoneOffset);
+        list.add(zoneOffset);
+        TestInner o = new TestInner();
+        list.add(o);
+        list.add(o);
+        list.add(zoneOffset);
+        list.add(o);
+        testJava8Time(list);
     }
 
     @Test
     public void testOffsetDateTime() throws Throwable {
-        testJava8Time(OffsetDateTime.now());
+        List<Object> list = new ArrayList<>();
+        OffsetDateTime offsetDateTime = OffsetDateTime.now();
+        list.add(offsetDateTime);
+        list.add(offsetDateTime);
+        TestInner o = new TestInner();
+        list.add(o);
+        list.add(o);
+        list.add(offsetDateTime);
+        list.add(o);
+        testJava8Time(list);
     }
 
     @Test
     public void testZonedDateTime() throws Exception {
-        testJava8Time(ZonedDateTime.now());
+        List<Object> list = new ArrayList<>();
+        ZonedDateTime zonedDateTime = ZonedDateTime.now();
+        list.add(zonedDateTime);
+        list.add(zonedDateTime);
+        TestInner o = new TestInner();
+        list.add(o);
+        list.add(o);
+        list.add(zonedDateTime);
+        list.add(o);
+        testJava8Time(list);
     }
 
     @Test
     public void testZoneId() throws Exception {
-        testJava8Time(ZoneId.of( "America/New_York"));
+        List<Object> list = new ArrayList<>();
+        ZoneId zoneId = ZoneId.of( "America/New_York");
+        list.add(zoneId);
+        list.add(zoneId);
+        TestInner o = new TestInner();
+        list.add(o);
+        list.add(o);
+        list.add(zoneId);
+        list.add(o);
+        testJava8Time(list);
     }
 
     @Test
     public void testCalendar() throws IOException {
+        List<Object> list = new ArrayList<>();
         Calendar calendar = Calendar.getInstance();
-        testJava8Time(calendar);
+        list.add(calendar);
+        list.add(calendar);
+        TestInner o = new TestInner();
+        list.add(o);
+        list.add(o);
+        list.add(calendar);
+        list.add(o);
+        testJava8Time(list);
     }
 
     @Test
@@ -152,8 +290,27 @@ public class Java8TimeSerializerTest extends SerializeTestBase {
         testJava8Time(ChronoPeriod.between(ThaiBuddhistDate.now(), ThaiBuddhistDate.now()));
     }
 
+
+    @Test
+    void testChronologyList() throws IOException {
+        List<Object> list = new ArrayList<>();
+        Chronology chronology = Chronology.of("islamic");
+        list.add(chronology);
+        list.add(chronology);
+        TestInner o = new TestInner();
+        list.add(o);
+        list.add(o);
+        list.add(chronology);
+        list.add(o);
+        testJava8Time(list);
+    }
+
     protected void testJava8Time(Object expected) throws IOException {
-        Assertions.assertEquals(expected, baseHessian2Serialize(expected));
+        Object result = baseHessian2Serialize(expected);
+        Assertions.assertEquals(expected, result);
+        if (expected instanceof List && ((List) expected).get(0) instanceof Chronology) {
+            return;
+        }
         if (expected instanceof Chronology || expected instanceof ChronoPeriod || expected instanceof JapaneseDate
                 || expected instanceof HijrahDate || expected instanceof MinguoDate || expected instanceof ThaiBuddhistDate) {
             return;
@@ -161,5 +318,25 @@ public class Java8TimeSerializerTest extends SerializeTestBase {
         Assertions.assertEquals(expected, hessian3ToHessian3(expected));
         Assertions.assertEquals(expected, hessian4ToHessian3(expected));
         Assertions.assertEquals(expected, hessian3ToHessian4(expected));
+    }
+    
+    static class TestInner implements Serializable {
+        String value;
+        
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            }
+            if (o instanceof TestInner) {
+                return Objects.equals(((TestInner) o).value, value);
+            }
+            return false;
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(value);
+        }
     }
 }

--- a/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/Java8TimeSerializerUseCompactModeTest.java
+++ b/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/Java8TimeSerializerUseCompactModeTest.java
@@ -53,7 +53,7 @@ public class Java8TimeSerializerUseCompactModeTest extends Java8TimeSerializerTe
 
     protected void testJava8Time(Object expected) throws IOException {
         Assertions.assertEquals(expected, baseHessian2Serialize(expected));
-        if (expected instanceof List && ((List) expected).get(0) instanceof Chronology) {
+        if (expected instanceof List && !((List) expected).isEmpty() && ((List) expected).get(0) instanceof Chronology) {
             return;
         }
         if (expected instanceof Chronology || expected instanceof ChronoPeriod || expected instanceof JapaneseDate

--- a/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/Java8TimeSerializerUseCompactModeTest.java
+++ b/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/java8/Java8TimeSerializerUseCompactModeTest.java
@@ -29,6 +29,7 @@ import java.time.chrono.HijrahDate;
 import java.time.chrono.JapaneseDate;
 import java.time.chrono.MinguoDate;
 import java.time.chrono.ThaiBuddhistDate;
+import java.util.List;
 
 /**
  * Test Java8TimeSerializer class use compact mode
@@ -52,6 +53,9 @@ public class Java8TimeSerializerUseCompactModeTest extends Java8TimeSerializerTe
 
     protected void testJava8Time(Object expected) throws IOException {
         Assertions.assertEquals(expected, baseHessian2Serialize(expected));
+        if (expected instanceof List && ((List) expected).get(0) instanceof Chronology) {
+            return;
+        }
         if (expected instanceof Chronology || expected instanceof ChronoPeriod || expected instanceof JapaneseDate
                 || expected instanceof HijrahDate || expected instanceof MinguoDate || expected instanceof ThaiBuddhistDate) {
             return;


### PR DESCRIPTION
1. Simplified reference counting by using the size of the ```_refs``` collection instead of maintaining a separate counter
2. Lazy calling ```addRef``` at ```AbstractSerializer#writeObject``` to make the reference value of the replaced object correct.

To fix such issue,
<img width="1245" height="655" alt="b164e3acb084256290fa7cea7dea1b7a" src="https://github.com/user-attachments/assets/a99d8a21-af61-4ac9-9334-d3fe84862208" />

TODO:
The xxxSerializers which used ```HessianHandle``` implementation to serialize object should implement ```writeReplace``` to decrease resource occupation.