### PR TITLE
perf: When deserializing allocate init capacity directly according to the expected size to avoid resize.

### DIFF
--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/CollectionDeserializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/CollectionDeserializer.java
@@ -78,7 +78,7 @@ public class CollectionDeserializer extends AbstractListDeserializer {
 
     @Override
     public Object readList(AbstractHessianInput in, int length, Class<?> expectType) throws IOException {
-        Collection list = createList();
+        Collection list = createList(length);
 
         in.addRef(list);
 
@@ -106,7 +106,7 @@ public class CollectionDeserializer extends AbstractListDeserializer {
 
     @Override
     public Object readLengthList(AbstractHessianInput in, int length, Class<?> expectType) throws IOException {
-        Collection list = createList();
+        Collection list = createList(length);
 
         in.addRef(list);
 
@@ -125,12 +125,12 @@ public class CollectionDeserializer extends AbstractListDeserializer {
         return list;
     }
 
-    private Collection createList()
+    private Collection createList(int expectedSize)
             throws IOException {
         Collection list = null;
 
         if (_type == null)
-            list = new ArrayList();
+            list = new ArrayList(expectedSize);
         else if (!_type.isInterface()) {
             try {
                 list = (Collection) _type.newInstance();
@@ -142,11 +142,9 @@ public class CollectionDeserializer extends AbstractListDeserializer {
         } else if (SortedSet.class.isAssignableFrom(_type))
             list = new TreeSet();
         else if (Set.class.isAssignableFrom(_type))
-            list = new HashSet();
-        else if (List.class.isAssignableFrom(_type))
-            list = new ArrayList();
+            list = new HashSet(MapUtil.capacity(expectedSize));
         else if (Collection.class.isAssignableFrom(_type))
-            list = new ArrayList();
+            list = new ArrayList(expectedSize);
         else {
             try {
                 list = (Collection) _type.newInstance();

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/MapDeserializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/MapDeserializer.java
@@ -150,7 +150,7 @@ public class MapDeserializer extends AbstractMapDeserializer {
                              Object[] fields)
             throws IOException {
         String[] fieldNames = (String[]) fields;
-        Map<Object, Object> map = createMap();
+        Map<Object, Object> map = createMap(fieldNames.length);
 
         int ref = in.addRef(map);
 
@@ -163,13 +163,11 @@ public class MapDeserializer extends AbstractMapDeserializer {
         return map;
     }
 
-    private Map createMap()
+    private Map createMap(int expectedSize)
             throws IOException {
 
-        if (_type == null)
-            return new HashMap();
-        else if (_type.equals(Map.class))
-            return new HashMap();
+        if (_type == null || _type.equals(Map.class) || _type.equals(HashMap.class))
+            return new HashMap(MapUtil.capacity(expectedSize));
         else if (_type.equals(SortedMap.class))
             return new TreeMap();
         else {

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/MapUtil.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/MapUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.com.caucho.hessian.io;
+
+
+class MapUtil {
+
+  private static final int MAX_POWER_OF_TWO = 1 << (Integer.SIZE - 2);
+
+  protected static int capacity(int expectedSize) {
+    if (expectedSize < 3) {
+      checkNonNegative(expectedSize, "expectedSize");
+      return expectedSize + 1;
+    }
+    if (expectedSize < MAX_POWER_OF_TWO) {
+      // This is the calculation used in JDK8 to resize when a putAll
+      // happens; it seems to be the most conservative calculation we
+      // can make.  0.75 is the default load factor.
+      return (int) ((float) expectedSize / 0.75F + 1.0F);
+    }
+    return Integer.MAX_VALUE;
+  }
+
+  private static int checkNonNegative(int value, String name) {
+    if (value < 0) {
+      throw new IllegalArgumentException(name + " cannot be negative but was: " + value);
+    }
+    return value;
+  }
+
+}

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/MapUtil.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/MapUtil.java
@@ -21,9 +21,17 @@ class MapUtil {
 
   private static final int MAX_POWER_OF_TWO = 1 << (Integer.SIZE - 2);
 
+  /**
+   * @see java.util.HashMap#DEFAULT_INITIAL_CAPACITY
+   */
+  private static final int DEFAULT_INITIAL_CAPACITY = 1 << 4;
+
   protected static int capacity(int expectedSize) {
+    if (expectedSize < 0) {
+      return DEFAULT_INITIAL_CAPACITY;
+    }
+
     if (expectedSize < 3) {
-      checkNonNegative(expectedSize, "expectedSize");
       return expectedSize + 1;
     }
     if (expectedSize < MAX_POWER_OF_TWO) {
@@ -33,13 +41,6 @@ class MapUtil {
       return (int) ((float) expectedSize / 0.75F + 1.0F);
     }
     return Integer.MAX_VALUE;
-  }
-
-  private static int checkNonNegative(int value, String name) {
-    if (value < 0) {
-      throw new IllegalArgumentException(name + " cannot be negative but was: " + value);
-    }
-    return value;
   }
 
 }


### PR DESCRIPTION
When deserializing allocate init capacity directly according to the expected size to avoid resize.