### PR TITLE
Fix annotation deserialization data type mismatch issue

### DIFF
--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AnnotationInvocationHandler.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AnnotationInvocationHandler.java
@@ -86,7 +86,16 @@ public class AnnotationInvocationHandler implements InvocationHandler {
             return null;
 
 
-        return _valueMap.get(method.getName());
+        Object value = _valueMap.get(method.getName());
+
+        if (method.getReturnType().equals(byte.class) && value instanceof Integer) {
+            return ((Integer) value).byteValue();
+        } else if (method.getReturnType().equals(short.class) && value instanceof Integer) {
+            return ((Integer) value).shortValue();
+        } else if (method.getReturnType().equals(float.class) && value instanceof Double) {
+            return ((Double) value).floatValue();
+        }
+        return value;
     }
 
     public int doHashCode() {

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AnnotationInvocationHandler.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AnnotationInvocationHandler.java
@@ -87,12 +87,12 @@ public class AnnotationInvocationHandler implements InvocationHandler {
 
 
         Object value = _valueMap.get(method.getName());
-
-        if (method.getReturnType().equals(byte.class) && value instanceof Integer) {
+        Class<?> returnType = method.getReturnType();
+        if (byte.class.equals(returnType) && value instanceof Integer) {
             return ((Integer) value).byteValue();
-        } else if (method.getReturnType().equals(short.class) && value instanceof Integer) {
+        } else if (short.class.equals(returnType) && value instanceof Integer) {
             return ((Integer) value).shortValue();
-        } else if (method.getReturnType().equals(float.class) && value instanceof Double) {
+        } else if (float.class.equals(returnType) && value instanceof Double) {
             return ((Double) value).floatValue();
         }
         return value;

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AnnotationSerializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AnnotationSerializer.java
@@ -274,7 +274,14 @@ public class AnnotationSerializer extends AbstractSerializer {
             int value = 0;
 
             try {
-                value = Integer.parseInt(method.invoke(obj).toString());
+                Object ret = method.invoke(obj);
+                if (ret instanceof Byte) {
+                    value = (Byte) ret;
+                } else if (ret instanceof Short) {
+                    value = (Short) ret;
+                } else {
+                    value = (Integer) ret;
+                }
             } catch (InvocationTargetException e) {
                 throw error(method, e.getCause());
             } catch (IllegalAccessException e) {
@@ -312,7 +319,12 @@ public class AnnotationSerializer extends AbstractSerializer {
             double value = 0;
 
             try {
-                value = Double.parseDouble(method.invoke(obj).toString());
+                Object ret = method.invoke(obj);
+                if (ret instanceof Float) {
+                    value = (Float) ret;
+                } else {
+                    value = (Double) ret;
+                }
             } catch (InvocationTargetException e) {
                 throw error(method, e.getCause());
             } catch (IllegalAccessException e) {

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AnnotationSerializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AnnotationSerializer.java
@@ -274,7 +274,7 @@ public class AnnotationSerializer extends AbstractSerializer {
             int value = 0;
 
             try {
-                value = Integer.parseInt(method.invoke(obj).toString());;
+                value = Integer.parseInt(method.invoke(obj).toString());
             } catch (InvocationTargetException e) {
                 throw error(method, e.getCause());
             } catch (IllegalAccessException e) {

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AnnotationSerializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/AnnotationSerializer.java
@@ -80,8 +80,7 @@ public class AnnotationSerializer extends AbstractSerializer {
     private static MethodSerializer getMethodSerializer(Class type) {
         if (int.class.equals(type)
                 || byte.class.equals(type)
-                || short.class.equals(type)
-                || int.class.equals(type)) {
+                || short.class.equals(type)) {
             return IntMethodSerializer.SER;
         } else if (long.class.equals(type)) {
             return LongMethodSerializer.SER;
@@ -275,7 +274,7 @@ public class AnnotationSerializer extends AbstractSerializer {
             int value = 0;
 
             try {
-                value = (Integer) method.invoke(obj);
+                value = Integer.parseInt(method.invoke(obj).toString());;
             } catch (InvocationTargetException e) {
                 throw error(method, e.getCause());
             } catch (IllegalAccessException e) {
@@ -313,7 +312,7 @@ public class AnnotationSerializer extends AbstractSerializer {
             double value = 0;
 
             try {
-                value = (Double) method.invoke(obj);
+                value = Double.parseDouble(method.invoke(obj).toString());
             } catch (InvocationTargetException e) {
                 throw error(method, e.getCause());
             } catch (IllegalAccessException e) {

--- a/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/AnnotationTest.java
+++ b/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/AnnotationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.com.caucho.hessian.io;
+
+import com.alibaba.com.caucho.hessian.io.base.SerializeTestBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+public class AnnotationTest extends SerializeTestBase {
+    @Test
+    void test() throws IOException {
+        TestAnnotation annotation = AnnotatedClass.class.getAnnotation(TestAnnotation.class);
+
+        TestAnnotation testAnnotation = baseHessian2Serialize(annotation);
+
+        Assertions.assertEquals(annotation, testAnnotation);
+    }
+
+    @TestAnnotation(byteValue = 1, intValue = 2, shortValue = 3, floatValue = 4.0f, doubleValue = 5.0, value = "test")
+    public static class AnnotatedClass {
+    }
+    
+    @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @interface TestAnnotation {
+        String value() default "default";
+        
+        int intValue() default 0;
+        
+        byte byteValue() default 0;
+
+        short shortValue() default 0;
+        
+        float floatValue() default 1.0001f;
+
+        double doubleValue() default 2.0001;
+    }
+}


### PR DESCRIPTION

```
    @Test
    void test() throws IOException {
        TestAnnotation annotation = AnnotatedClass.class.getAnnotation(TestAnnotation.class);

        TestAnnotation testAnnotation = baseHessian2Serialize(annotation);

        Assertions.assertEquals(annotation, testAnnotation);
    }

    @TestAnnotation(byteValue = 1, intValue = 2, shortValue = 3, floatValue = 4.0f, doubleValue = 5.0, value = "test")
    public static class AnnotatedClass {
    }
```

```
java.lang.ClassCastException: java.lang.Byte cannot be cast to java.lang.Integer

	at com.alibaba.com.caucho.hessian.io.AnnotationSerializer$IntMethodSerializer.serialize(AnnotationSerializer.java:278)
	at com.alibaba.com.caucho.hessian.io.AnnotationSerializer.writeInstance(AnnotationSerializer.java:162)
	at com.alibaba.com.caucho.hessian.io.AnnotationSerializer.writeObject(AnnotationSerializer.java:129)
	at com.alibaba.com.caucho.hessian.io.Hessian2Output.writeObject(Hessian2Output.java:431)
	at com.alibaba.com.caucho.hessian.io.base.SerializeTestBase.baseHessian2Serialize(SerializeTestBase.java:44)
```