### PR TITLE
fix: improve reference handling in InetSocketAddress deserialization

### DIFF
--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/socket/InetSocketAddressDeserializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/socket/InetSocketAddressDeserializer.java
@@ -49,6 +49,9 @@ public class InetSocketAddressDeserializer extends AbstractDeserializer {
                              String[] fieldNames)
             throws IOException {
         try {
+
+            int ref = in.addRef(null);
+
             String hostName = null;
             InetAddress address = null;
             int port = 0;
@@ -73,8 +76,7 @@ public class InetSocketAddressDeserializer extends AbstractDeserializer {
                 obj = new InetSocketAddress(port);
             }
 
-            in.addRef(obj);
-
+            in.setRef(ref, obj);
             return obj;
         } catch (IOException e) {
             throw e;

--- a/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/socket/InetSocketAddressTest.java
+++ b/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/socket/InetSocketAddressTest.java
@@ -23,10 +23,11 @@ import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import java.io.IOException;
-import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
 
 public class InetSocketAddressTest extends SerializeTestBase {
     @Test
@@ -88,5 +89,12 @@ public class InetSocketAddressTest extends SerializeTestBase {
     void testJdk17() throws Exception {
         InetSocketAddress inetSocketAddress = new InetSocketAddress("localhost", 8080);
         Assertions.assertEquals(inetSocketAddress, baseHessian2Serialize(inetSocketAddress));
+    }
+    
+    @Test
+    void testCollectionRef() throws IOException {
+        InetSocketAddress inetSocketAddress = new InetSocketAddress("localhost", 8080);
+        List<Object> list = new ArrayList<>();
+        testCollection(list, inetSocketAddress);
     }
 }


### PR DESCRIPTION
```java
@Test
    void testCollectionRef() throws IOException {
        InetSocketAddress inetSocketAddress = new InetSocketAddress("localhost", 8080);
        List<Object> list = new ArrayList<>();
        testCollection(list, inetSocketAddress);
    }
```

test failed
```
org.opentest4j.AssertionFailedError: 
Expected :localhost/127.0.0.1:8080
Actual   :localhost/127.0.0.1
```