### PR TITLE
Add support for BigInteger deserialization (when -Dcom.caucho.hessian.unsafe=false)

### DIFF
--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/BigIntegerDeserializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/BigIntegerDeserializer.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.com.caucho.hessian.io;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Arrays;
+
+/**
+ * Deserializing a BigInteger
+ */
+public class BigIntegerDeserializer extends AbstractDeserializer {
+
+    @Override
+    public Class<?> getType() {
+        return BigInteger.class;
+    }
+
+    @Override
+    public Object readObject(AbstractHessianInput in,
+                             Object[] fieldNames)
+            throws IOException {
+
+        int i = in.addRef(null);
+
+        Integer signum = null;
+        byte[] magnitude = null;
+        for (Object fieldName : fieldNames) {
+            if ("signum".equals(fieldName)) {
+                signum = in.readInt();
+            } else if ("mag".equals(fieldName)) {
+                magnitude = magSerializedForm((int[])in.readObject());
+            } else {
+                in.readObject();
+            }
+        }
+
+        if (signum == null || magnitude == null) {
+            throw new IOException("Missing required fields for BigInteger deserialization: "
+                    + "signum=" + signum + ", mag=" + Arrays.toString(magnitude));
+        }
+
+        BigInteger bigInteger = new BigInteger(signum, magnitude);
+        in.setRef(i, bigInteger);
+        return bigInteger;
+    }
+
+    static int bitLengthForInt(int n) {
+        return 32 - Integer.numberOfLeadingZeros(n);
+    }
+
+    /**
+     * copy from BigInteger#magSerializedForm()
+     */
+    private byte[] magSerializedForm(int mag[]) {
+        int len = mag.length;
+
+        int bitLen = (len == 0 ? 0 : ((len - 1) << 5) + bitLengthForInt(mag[0]));
+        int byteLen = (bitLen + 7) >>> 3;
+        byte[] result = new byte[byteLen];
+
+        for (int i = byteLen - 1, bytesCopied = 4, intIndex = len - 1, nextInt = 0;
+             i >= 0; i--) {
+            if (bytesCopied == 4) {
+                nextInt = mag[intIndex--];
+                bytesCopied = 1;
+            } else {
+                nextInt >>>= 8;
+                bytesCopied++;
+            }
+            result[i] = (byte)nextInt;
+        }
+        return result;
+    }
+}

--- a/hessian-lite/src/main/resources/META-INF/dubbo/hessian/deserializers
+++ b/hessian-lite/src/main/resources/META-INF/dubbo/hessian/deserializers
@@ -1,5 +1,6 @@
 java.io.File=com.alibaba.com.caucho.hessian.io.FileDeserializer
 java.math.BigDecimal=com.alibaba.com.caucho.hessian.io.BigDecimalDeserializer
+java.math.BigInteger=com.alibaba.com.caucho.hessian.io.BigIntegerDeserializer
 javax.management.ObjectName=com.alibaba.com.caucho.hessian.io.ObjectNameDeserializer
 java.util.concurrent.atomic.LongAdder$SerializationProxy=com.alibaba.com.caucho.hessian.io.atomic.LongAdderDeserializer
 java.net.InetAddress=com.alibaba.com.caucho.hessian.io.socket.InetAddressDeserializer

--- a/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/BigIntegerTest.java
+++ b/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/BigIntegerTest.java
@@ -38,6 +38,36 @@ public class BigIntegerTest extends SerializeTestBase {
     }
 
     @Test
+    void testWithUnsafeDisabled() throws IOException {
+        String originalUnsafeProp = System.getProperty("com.caucho.hessian.unsafe");
+        try {
+            System.setProperty("com.caucho.hessian.unsafe", "false");
+
+            BigInteger originalBigInteger = new BigInteger("1234567890");
+            BigInteger result = baseHessian2Serialize(originalBigInteger);
+            Assertions.assertEquals(originalBigInteger, result);
+
+            // Test with larger value
+            BigInteger largeBigInteger = new BigInteger("123456789012345678901234567890");
+            BigInteger largeResult = baseHessian2Serialize(largeBigInteger);
+            Assertions.assertEquals(largeBigInteger, largeResult);
+
+            // Test with negative value
+            BigInteger negativeBigInteger = new BigInteger("-9876543210");
+            BigInteger negativeResult = baseHessian2Serialize(negativeBigInteger);
+            Assertions.assertEquals(negativeBigInteger, negativeResult);
+
+            testCollection();
+        } finally {
+            if (originalUnsafeProp != null) {
+                System.setProperty("com.caucho.hessian.unsafe", originalUnsafeProp);
+            } else {
+                System.clearProperty("com.caucho.hessian.unsafe");
+            }
+        }
+    }
+
+    @Test
     @EnabledForJreRange(max = JRE.JAVA_11)
     void testCompact() throws IOException {
         BigInteger obj = new BigInteger("1234567890");


### PR DESCRIPTION
Add support for BigInteger deserialization, ensuring compatibility with both
Unsafe-enabled and Unsafe-disabled modes (when -Dcom.caucho.hessian.unsafe=false),
while remaining fully compatible with the original serialized data format.

fixed #101 

Related-to: https://github.com/apache/dubbo/issues/15750