### PR TITLE
Read object definition field names before sizing the arrays

### DIFF
--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/Hessian2Input.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/Hessian2Input.java
@@ -2921,6 +2921,14 @@ public class Hessian2Input
         String type = readString();
         int len = readInt();
 
+        // one byte per field name minimum, so the count is bounded by
+        // the remaining bytes
+        long remaining = _length - _offset + (long) _is.available();
+
+        if (len > remaining)
+            throw error("bad field count " + len + " in object definition '"
+                    + type + "', only " + remaining + " bytes left");
+
         SerializerFactory factory = findSerializerFactory();
 
         Deserializer reader = factory.getObjectDeserializer(type, null);

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/Hessian2Input.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/Hessian2Input.java
@@ -2921,26 +2921,33 @@ public class Hessian2Input
         String type = readString();
         int len = readInt();
 
-        // one byte per field name minimum, so the count is bounded by
-        // the remaining bytes
-        long remaining = _length - _offset + (long) _is.available();
-
-        if (len > remaining)
+        if (len < 0)
             throw error("bad field count " + len + " in object definition '"
-                    + type + "', only " + remaining + " bytes left");
+                    + type + "'");
 
         SerializerFactory factory = findSerializerFactory();
 
         Deserializer reader = factory.getObjectDeserializer(type, null);
 
-        Object[] fields = reader.createFields(len);
-        String[] fieldNames = new String[len];
+        // each field name takes at least one byte, so reading the names
+        // first bounds the arrays by the input actually supplied
+        ArrayList<String> nameList = new ArrayList<String>();
 
         for (int i = 0; i < len; i++) {
-            String name = readString();
+            if (read() < 0)
+                throw error("truncated object definition '" + type + "': "
+                        + i + " of " + len + " field names read");
 
-            fields[i] = reader.createField(name);
-            fieldNames[i] = name;
+            unread();
+
+            nameList.add(readString());
+        }
+
+        Object[] fields = reader.createFields(nameList.size());
+        String[] fieldNames = nameList.toArray(new String[0]);
+
+        for (int i = 0; i < fieldNames.length; i++) {
+            fields[i] = reader.createField(fieldNames[i]);
         }
 
         ObjectDefinition def

--- a/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/issue108/ObjectDefinitionFieldCountTest.java
+++ b/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/issue108/ObjectDefinitionFieldCountTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.com.caucho.hessian.io.issue108;
+
+import com.alibaba.com.caucho.hessian.io.Hessian2Input;
+import com.alibaba.com.caucho.hessian.io.HessianProtocolException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+
+public class ObjectDefinitionFieldCountTest {
+
+    @Test
+    void testHugeFieldCount() {
+        byte[] bytes = {(byte) 0x43, 0x01, 0x78, 0x49,
+                (byte) 0x7f, (byte) 0xff, (byte) 0xff, (byte) 0xff};
+        Hessian2Input input = new Hessian2Input(new ByteArrayInputStream(bytes));
+
+        Assertions.assertThrows(HessianProtocolException.class, input::readObject);
+    }
+
+    @Test
+    void testFieldCountAtRemaining() {
+        // 'C' 'x' count=6, then six empty field names
+        byte[] bytes = {0x43, 0x01, 0x78, 0x49, 0x00, 0x00, 0x00, 0x06,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        Hessian2Input input = new Hessian2Input(new ByteArrayInputStream(bytes));
+
+        Assertions.assertThrows(EOFException.class, input::readObject);
+    }
+}

--- a/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/issue108/ObjectDefinitionFieldCountTest.java
+++ b/java-8-test/src/test/java/com/alibaba/com/caucho/hessian/io/issue108/ObjectDefinitionFieldCountTest.java
@@ -17,12 +17,17 @@
 package com.alibaba.com.caucho.hessian.io.issue108;
 
 import com.alibaba.com.caucho.hessian.io.Hessian2Input;
+import com.alibaba.com.caucho.hessian.io.Hessian2Output;
 import com.alibaba.com.caucho.hessian.io.HessianProtocolException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
 
 public class ObjectDefinitionFieldCountTest {
 
@@ -32,16 +37,98 @@ public class ObjectDefinitionFieldCountTest {
                 (byte) 0x7f, (byte) 0xff, (byte) 0xff, (byte) 0xff};
         Hessian2Input input = new Hessian2Input(new ByteArrayInputStream(bytes));
 
-        Assertions.assertThrows(HessianProtocolException.class, input::readObject);
+        HessianProtocolException e = Assertions.assertThrows(
+                HessianProtocolException.class, input::readObject);
+        Assertions.assertTrue(e.getMessage().contains("truncated object definition"));
     }
 
     @Test
-    void testFieldCountAtRemaining() {
+    void testNegativeFieldCount() {
+        byte[] bytes = {0x43, 0x01, 0x78, 0x49,
+                (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff};
+        Hessian2Input input = new Hessian2Input(new ByteArrayInputStream(bytes));
+
+        HessianProtocolException e = Assertions.assertThrows(
+                HessianProtocolException.class, input::readObject);
+        Assertions.assertTrue(e.getMessage().contains("bad field count -1"));
+    }
+
+    @Test
+    void testFieldNamesArrivingInPieces() {
         // 'C' 'x' count=6, then six empty field names
         byte[] bytes = {0x43, 0x01, 0x78, 0x49, 0x00, 0x00, 0x00, 0x06,
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-        Hessian2Input input = new Hessian2Input(new ByteArrayInputStream(bytes));
+        Hessian2Input input = new Hessian2Input(new DribbleInputStream(bytes));
 
         Assertions.assertThrows(EOFException.class, input::readObject);
+    }
+
+    @Test
+    void testRoundTripThroughDribblingStream() throws IOException {
+        SampleBean bean = new SampleBean();
+        bean.setName("issue-108");
+        bean.setCount(6);
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        Hessian2Output out = new Hessian2Output(bout);
+        out.writeObject(bean);
+        out.flush();
+
+        Hessian2Input input = new Hessian2Input(
+                new DribbleInputStream(bout.toByteArray()));
+        SampleBean copy = (SampleBean) input.readObject();
+
+        Assertions.assertEquals(bean.getName(), copy.getName());
+        Assertions.assertEquals(bean.getCount(), copy.getCount());
+    }
+
+    public static class SampleBean implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private String name;
+        private int count;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public void setCount(int count) {
+            this.count = count;
+        }
+    }
+
+    static class DribbleInputStream extends InputStream {
+        private final byte[] bytes;
+        private int offset;
+
+        DribbleInputStream(byte[] bytes) {
+            this.bytes = bytes;
+        }
+
+        @Override
+        public int read() {
+            if (offset >= bytes.length)
+                return -1;
+
+            return bytes[offset++] & 0xff;
+        }
+
+        @Override
+        public int read(byte[] buffer, int off, int len) {
+            if (offset >= bytes.length)
+                return -1;
+
+            buffer[off] = bytes[offset++];
+
+            return 1;
+        }
     }
 }


### PR DESCRIPTION
What is the purpose of the change

Stop sizing the object definition arrays from the field count alone; a truncated definition now fails as malformed input instead of exhausting memory on the allocation.

Fixes #108

Problem

readObjectDefinition takes the field count at face value: both arrays are sized from it on the spot, the field names are read afterwards, and nothing measures the count against the bytes the stream actually holds. A short stream carrying a huge count therefore turns into a huge allocation request, and readObject fails with OutOfMemoryError before a single field name has been read. A count below zero fails as a raw NegativeArraySizeException rather than a protocol error. Reproducer streams are in the issue.

Solution

The field names are collected before any allocation, and both arrays are sized only after the last one is read. A count below zero is rejected, and a stream that ends mid-definition reports how many names it read before failing.

java-8-test gains the issue's reproducer, a test that a count below zero is rejected, a test that the dribbling input accepts a well-formed definition, and a bean round trip through the same stream. The full module suite passes locally, with the fix built from source.
